### PR TITLE
エディターで改行した時のインデントが4になるように調整

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-python": "6.1.7",
+        "@codemirror/language": "6.10.8",
         "@codemirror/theme-one-dark": "6.1.2",
         "@uiw/react-codemirror": "4.23.10",
         "lucide-react": "^0.344.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "react-router-dom": "^6.22.3",
     "@uiw/react-codemirror": "4.23.10",
     "@codemirror/theme-one-dark": "6.1.2",
-    "@codemirror/lang-python": "6.1.7"
+    "@codemirror/lang-python": "6.1.7",
+    "@codemirror/language": "6.10.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -19,6 +19,7 @@ import { challengesData } from './challengesData';
 import CodeMirror from '@uiw/react-codemirror';
 import { python } from '@codemirror/lang-python';
 import { oneDark } from '@codemirror/theme-one-dark';
+import { indentUnit } from '@codemirror/language';
 
 
 function SuccessModal({ message, onClose }) {
@@ -415,7 +416,7 @@ function ChallengeEditor() {
                 <CodeMirror
                   value={code}
                   height="100%"
-                  extensions={[python(), oneDark]}
+                  extensions={[python(), oneDark, indentUnit.of('    ')]}
                   onChange={(value) => setCode(value)}
                   className="w-full h-full font-mono text-sm bg-transparent text-slate-200 outline-none resize-none"
                 />


### PR DESCRIPTION
## 修正箇所
- エディターで改行した時にインデントが2になるが、`python`を書きたいのでインデントが4になるように調整しました（インデントが2でも動きはしますが...）

## 動作チェック
- [ ] エディターで改行した時にインデントが4になっている