### PR TITLE
AIコード生成をプロンプトではなく、難易度を選択する形式に変更

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -80,7 +80,15 @@ class TestHandler(http.server.SimpleHTTPRequestHandler):
 
         elif self.path == "/api/generate-code":
             data_gen: Dict[str, Any] = self.parse_json_from_request()
-            prompt: str = data_gen.get("prompt", "")
+            challenge = data_gen.get("challenge", "")
+            difficulty = data_gen.get("difficulty", "")
+            prompt = f"""
+            課題:
+            {challenge}
+
+            エラーの見つけやすさ：
+            {difficulty}
+            """
             try:
                 generated_code: str = self.generate_code_from_prompt(prompt)
                 self.send_json_response({"code": generated_code})

--- a/backend/server.py
+++ b/backend/server.py
@@ -27,7 +27,9 @@ Reason about **what kind of bugs students may make** while coming up with soluti
 }
 Implement only this function with various bugs that students may make, incorporating the bugs you reasoned about. Each program should contain only one bug. Make them as diverse as possible. The bugs should not lead to the program not compiling or hanging. Do not add comments.  Do not forget to first reason about possible bugs. 
 Make sure that the function name is `main`.
-Problem Description: 
+Problem Description:
+
+In addition to the Problem, the user will provide a difficulty level for bug detection in Japanese, chosen from "やさしい" (easy to find bugs), "ちょっとわかりにくい" (slightly difficult to find bugs), or "かなりわかりにくい" (very difficult to find bugs). The three buggy implementations you generate should reflect the chosen difficulty level of bug detection. The code itself does not need to be intrinsically complex, but the bugs should be designed to be easily, moderately, or very difficult to identify based on the chosen level.
 """
 
 HINT_SYSTEM_INSTRUCTION: str = """\

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -135,7 +135,7 @@ function ChallengeEditor() {
   const [testResults, setTestResults] = useState([]);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [prompt, setPrompt] = useState('');
+  const [difficulty, setDifficulty] = useState('やさしい');
   const [generationError, setGenerationError] = useState('');
   const [showHintModal, setShowHintModal] = useState(false);
   const [hint, setHint] = useState('');
@@ -151,7 +151,10 @@ function ChallengeEditor() {
         method: 'POST',
         mode: 'cors',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ 
+          challenge: challenge?.instructions,
+          difficulty,
+          }),
       });
 
       const data = await response.json();
@@ -250,6 +253,7 @@ function ChallengeEditor() {
     setHintError('');
     
     try {
+      console.log(challenge?.instructions);
       const response = await fetch('http://localhost:8000/api/generate-hint', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -373,20 +377,28 @@ function ChallengeEditor() {
                 まずは、AIアシスタントを使ってコードを生成しよう！
               </h2>
               <p className="text-slate-600 text-sm mb-4">
-                プロンプトを使ってAIにコードを書かせて、<br />
+                「エラーの見つけやすさ」を選択してAIにコードを書かせて、<br />
                 生成されたコードを修正してテストを実行しよう！
               </p>
 
               <label className="block mb-1 font-medium text-slate-700 text-sm">
-                AIへの指示
+                エラーの見つけやすさ
               </label>
-              <textarea
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                placeholder="AIにさせたい処理を具体的に入力してください..."
+              <select
+                value={difficulty}
+                onChange={(e) => setDifficulty(e.target.value)}
                 className="w-full p-2 border border-slate-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                rows={3}
-              />
+                style={{
+                  whiteSpace: 'normal',
+                  overflow: 'visible',
+                  textOverflow: 'clip',
+                  maxWidth: '100%'
+                }}
+              >
+                <option value="やさしい" className="w-full">やさしい</option>
+                <option value="ちょっとわかりにくい">ちょっとわかりにくい</option>
+                <option value="かなりわかりにくい">かなりわかりにくい</option>
+              </select>
 
               <button
                 onClick={handleGenerateCode}

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -253,7 +253,6 @@ function ChallengeEditor() {
     setHintError('');
     
     try {
-      console.log(challenge?.instructions);
       const response = await fetch('http://localhost:8000/api/generate-hint', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -384,21 +383,58 @@ function ChallengeEditor() {
               <label className="block mb-1 font-medium text-slate-700 text-sm">
                 エラーの見つけやすさ
               </label>
-              <select
-                value={difficulty}
-                onChange={(e) => setDifficulty(e.target.value)}
-                className="w-full p-2 border border-slate-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                style={{
-                  whiteSpace: 'normal',
-                  overflow: 'visible',
-                  textOverflow: 'clip',
-                  maxWidth: '100%'
-                }}
-              >
-                <option value="やさしい" className="w-full">やさしい</option>
-                <option value="ちょっとわかりにくい">ちょっとわかりにくい</option>
-                <option value="かなりわかりにくい">かなりわかりにくい</option>
-              </select>
+              
+              <div className="w-full max-w-3xl mx-auto py-8">
+      <div className="relative mt-1 flex items-center justify-between">
+        {/* Connecting line */}
+        <div className="absolute top-6 left-2 h-0.5 bg-blue-400 w-[90%] z-0"></div>
+
+        {/* Easy level */}
+        <div className="flex flex-col pt-1 items-center z-10">
+          <button
+            onClick={() => setDifficulty("やさしい")}
+            className={`
+              w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+            }
+            aria-pressed={difficulty === "やさしい"}
+          >
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "やさしい" ? "bg-blue-400" : "bg-white"}`} />
+            <span className="sr-only">やさしい</span>
+          </button>
+          <span className="text-center text-sm font-medium">やさしい</span>
+        </div>
+
+        {/* Medium level */}
+        <div className="flex flex-col pt-1 items-center z-10">
+          <button
+            onClick={() => setDifficulty("ちょっとわかりにくい")}
+            className={
+              `w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+            }
+            aria-pressed={difficulty === 'ちょっとわかりにくい'}
+          >
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "ちょっとわかりにくい" ? "bg-blue-400" : "bg-white"}`} />
+            <span className="sr-only">ちょっとわかりにくい</span>
+          </button>
+          <span className="text-center text-sm font-medium">ちょっとわかりにくい</span>
+        </div>
+
+        {/* Hard level */}
+        <div className="flex flex-col pt-1 items-center z-10">
+          <button
+            onClick={() => setDifficulty("かなりわかりにくい")}
+            className={
+              `w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+            }
+            aria-pressed={difficulty === 'かなりわかりにくい'}
+          >
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "かなりわかりにくい" ? "bg-blue-400" : "bg-white"}`} />
+            <span className="sr-only">かなりわかりにくい</span>
+          </button>
+          <span className="text-center text-sm font-medium">かなりわかりにくい</span>
+        </div>
+      </div>
+    </div>
 
               <button
                 onClick={handleGenerateCode}

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -387,18 +387,18 @@ function ChallengeEditor() {
               <div className="w-full max-w-3xl mx-auto py-8">
       <div className="relative mt-1 flex items-center justify-between">
         {/* Connecting line */}
-        <div className="absolute top-6 left-2 h-0.5 bg-blue-400 w-[90%] z-0"></div>
+        <div className="absolute top-6 left-2 h-0.5 bg-indigo-400 w-[90%] z-0"></div>
 
         {/* Easy level */}
         <div className="flex flex-col pt-1 items-center z-10">
           <button
             onClick={() => setDifficulty("やさしい")}
             className={`
-              w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+              w-10 h-10 bg-white rounded-full border-2 border-indigo-400 flex items-center justify-center mb-3 transition-colors`
             }
             aria-pressed={difficulty === "やさしい"}
           >
-            <div className={`w-5 h-5 rounded-full  ${difficulty === "やさしい" ? "bg-blue-400" : "bg-white"}`} />
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "やさしい" ? "bg-indigo-400" : "bg-white"}`} />
             <span className="sr-only">やさしい</span>
           </button>
           <span className="text-center text-sm font-medium">やさしい</span>
@@ -409,11 +409,11 @@ function ChallengeEditor() {
           <button
             onClick={() => setDifficulty("ちょっとわかりにくい")}
             className={
-              `w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+              `w-10 h-10 bg-white rounded-full border-2 border-indigo-400 flex items-center justify-center mb-3 transition-colors`
             }
             aria-pressed={difficulty === 'ちょっとわかりにくい'}
           >
-            <div className={`w-5 h-5 rounded-full  ${difficulty === "ちょっとわかりにくい" ? "bg-blue-400" : "bg-white"}`} />
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "ちょっとわかりにくい" ? "bg-indigo-400" : "bg-white"}`} />
             <span className="sr-only">ちょっとわかりにくい</span>
           </button>
           <span className="text-center text-sm font-medium">ちょっとわかりにくい</span>
@@ -424,11 +424,11 @@ function ChallengeEditor() {
           <button
             onClick={() => setDifficulty("かなりわかりにくい")}
             className={
-              `w-10 h-10 bg-white rounded-full border-2 border-blue-400 flex items-center justify-center mb-3 transition-colors`
+              `w-10 h-10 bg-white rounded-full border-2 border-indigo-400 flex items-center justify-center mb-3 transition-colors`
             }
             aria-pressed={difficulty === 'かなりわかりにくい'}
           >
-            <div className={`w-5 h-5 rounded-full  ${difficulty === "かなりわかりにくい" ? "bg-blue-400" : "bg-white"}`} />
+            <div className={`w-5 h-5 rounded-full  ${difficulty === "かなりわかりにくい" ? "bg-indigo-400" : "bg-white"}`} />
             <span className="sr-only">かなりわかりにくい</span>
           </button>
           <span className="text-center text-sm font-medium">かなりわかりにくい</span>

--- a/frontend/src/challengesData.ts
+++ b/frontend/src/challengesData.ts
@@ -200,7 +200,7 @@ export const challengesData: Challenge[] = [
 - config: ネストされた辞書（Pythonの dict）で、各キーの値は任意の型・構造。
 - spec: 同じ構造を持つ辞書で、各キーに対して期待される型や制約を指定します。
   - もし spec の値が文字列の場合、その値は期待される型を示します（例："string", "number", "boolean"）。
-  - もし spec の値がオブジェクトの場合、必ず "type" キーを持ち、数値の場合は任意で "min" および "max" を指定できます。例: { type: "number", min: 1, max: 65535 }。
+  - もし spec の値がオブジェクトの場合、必ず "type" キーを持ち、数値の場合は任意で "min" および "max" を指定できます。例: { "type": "number", "min": 1, "max": 65535 }。
   - ネストされた辞書の場合は、spec も同じ構造になっており、再帰的に検証します。
 
 【出力】


### PR DESCRIPTION
## 変更点
- AIコード生成時に、ユーザーにプロンプトを入力させるのではなく、「エラーの見つけやすさ」を選択させるようにした
- 「問題の説明」は難易度とは別でバックエンドに送るようにした
- 「動的設定バリデーター: ネスト設定の検証」の説明文中にあるjsonのフォーマットを変更


## 確認して欲しい点
- 「 動的設定バリデーター: ネスト設定の検証」の問題でたまに生成に失敗することがあります。
    下記のエラー内容を見て、説明文中のjsonが原因だと思い修正しましたが、まだうまくいっている確証がないです
```text
"Expecting ',' delimiter: line 2 column 825 (char 826)"
```
- 選択のドロップダウンのスタイルが僕のChromeだどなぜか文字が見切れます。Safariだと問題なかったです。
<img width="1512" alt="Screenshot 2025-03-14 at 16 27 39" src="https://github.com/user-attachments/assets/46a4d438-225d-4971-b329-e48224f61f20" />
