### PR TITLE
テスト結果表示を初心者にも分かりやすいUIに改善

### DIFF
--- a/backend/code_runner.py
+++ b/backend/code_runner.py
@@ -5,11 +5,6 @@ from copy import deepcopy
 from typing import Any, Dict, List
 
 
-def _format_test_result_message(input_data_list: List[Any], expected_output: str, actual_output: str) -> str:
-    """テスト結果のメッセージをフォーマットする共通関数"""
-    return f"Input:\n{'\n'.join(map(str, input_data_list))}\n\nExpected output:\n{expected_output}\n\nActual output:\n{actual_output}"
-
-
 def run_single_test_case(code: str, test_case: Dict[str, Any]) -> Dict[str, Any]:
     stdout_capture: io.StringIO = io.StringIO()
     try:
@@ -43,12 +38,14 @@ def run_single_test_case(code: str, test_case: Dict[str, Any]) -> Dict[str, Any]
         expected_output = str(test_case.get("expected")).strip()
         
         # Compare the outputs
-        message = _format_test_result_message(input_data_list, expected_output, actual_output)
         status = "success" if actual_output == expected_output else "error"
         
+        # Return structured data instead of formatted message
         return {
             "status": status,
-            "message": message,
+            "input": input_data_list,
+            "expected_output": expected_output,
+            "actual_output": actual_output,
         }
     except Exception as e:
         return {

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -617,30 +617,108 @@ function ChallengeEditor() {
                 {testResults.map((result, index) => (
                   <div
                     key={index}
-                    className={`mb-3 p-3 rounded-lg border-2 ${
+                    className={`mb-4 rounded-lg border-2 overflow-hidden ${
                       result.status === 'success' 
-                        ? 'bg-green-50 border-green-200' 
-                        : 'bg-red-50 border-red-200'
+                        ? 'bg-green-50 border-green-300' 
+                        : 'bg-red-50 border-red-300'
                     }`}
                   >
-                    <div className="flex items-start gap-2">
+                    <div className={`flex items-center gap-2 px-4 py-2 font-bold ${
+                      result.status === 'success' 
+                        ? 'bg-green-100 text-green-800' 
+                        : 'bg-red-100 text-red-800'
+                    }`}>
                       {result.status === 'success' ? (
-                        <CheckCircle className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                        <CheckCircle className="w-5 h-5 flex-shrink-0" />
                       ) : (
-                        <XCircle className="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" />
+                        <XCircle className="w-5 h-5 flex-shrink-0" />
                       )}
-                      <div className="flex-1">
-                        <div className={`font-bold mb-1 ${
-                          result.status === 'success' ? 'text-green-700' : 'text-red-700'
-                        }`}>
-                          テスト {result.testCase} {result.status === 'success' ? '✅' : '❌'}
+                      <span>テスト {result.testCase} {result.status === 'success' ? '✅' : '❌'}</span>
+                    </div>
+                    
+                    <div className="p-4 space-y-3">
+                      {result.status === 'forbidden' ? (
+                        <div className="text-sm text-red-700 font-medium">
+                          ⚠️ APIキーを抜き取ろうとするコードは許可されていません！
                         </div>
+                      ) : result.message ? (
                         <div className="text-sm text-slate-600 whitespace-pre-wrap">
-                          {result.status === 'forbidden'
-                            ? 'APIキーを抜き取ろうとするコードは許可されていません！'
-                            : result.message}
+                          {result.message}
                         </div>
-                      </div>
+                      ) : (
+                        <>
+                          {/* 入力データ */}
+                          <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+                            <div className="flex items-center gap-2 mb-2">
+                              <div className="bg-slate-600 text-white px-3 py-1 rounded-md text-xs font-bold">
+                                📥 入力データ
+                              </div>
+                            </div>
+                            <div className="text-sm font-mono bg-white px-3 py-2 rounded border border-slate-200">
+                              {result.input && result.input.length > 0 
+                                ? result.input.map((item, i) => (
+                                    <div key={i} className="text-slate-700">
+                                      {typeof item === 'string' ? `"${item}"` : String(item)}
+                                    </div>
+                                  ))
+                                : <span className="text-slate-400">なし</span>
+                              }
+                            </div>
+                          </div>
+
+                          {/* 期待される出力 */}
+                          <div className="bg-indigo-50 rounded-lg p-3 border border-indigo-200">
+                            <div className="flex items-center gap-2 mb-2">
+                              <div className="bg-indigo-600 text-white px-3 py-1 rounded-md text-xs font-bold">
+                                🎯 正しい答え（期待される出力）
+                              </div>
+                            </div>
+                            <div className="text-sm font-mono bg-white px-3 py-2 rounded border border-indigo-200 text-slate-700">
+                              {result.expected_output || <span className="text-slate-400">なし</span>}
+                            </div>
+                          </div>
+
+                          {/* 実際の出力 */}
+                          <div className={`rounded-lg p-3 border ${
+                            result.status === 'success' 
+                              ? 'bg-emerald-50 border-emerald-200' 
+                              : 'bg-rose-50 border-rose-200'
+                          }`}>
+                            <div className="flex items-center gap-2 mb-2">
+                              <div className={`text-white px-3 py-1 rounded-md text-xs font-bold ${
+                                result.status === 'success' 
+                                  ? 'bg-emerald-600' 
+                                  : 'bg-rose-600'
+                              }`}>
+                                💻 あなたのプログラムの出力
+                              </div>
+                            </div>
+                            <div className={`text-sm font-mono bg-white px-3 py-2 rounded border ${
+                              result.status === 'success' 
+                                ? 'border-emerald-200 text-slate-700' 
+                                : 'border-rose-200 text-slate-700'
+                            }`}>
+                              {result.actual_output || <span className="text-slate-400">出力なし</span>}
+                            </div>
+                          </div>
+
+                          {/* 比較結果の説明 */}
+                          {result.status !== 'success' && (
+                            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+                              <div className="flex gap-2">
+                                <span className="text-yellow-600 text-xl">💡</span>
+                                <div className="flex-1">
+                                  <div className="font-bold text-yellow-800 mb-1">ヒント</div>
+                                  <div className="text-sm text-yellow-700">
+                                    「正しい答え」と「あなたのプログラムの出力」を見比べてみましょう。<br/>
+                                    どこが違うかな？スペースや改行も確認してみてね！
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/frontend/src/components/TestResults.tsx
+++ b/frontend/src/components/TestResults.tsx
@@ -61,30 +61,108 @@ export function TestResults({
         {testResults.map((result, index) => (
           <div
             key={index}
-            className={`mb-3 p-3 rounded-lg border-2 ${
+            className={`mb-4 rounded-lg border-2 overflow-hidden ${
               result.status === 'success' 
-                ? 'bg-green-50 border-green-200' 
-                : 'bg-red-50 border-red-200'
+                ? 'bg-green-50 border-green-300' 
+                : 'bg-red-50 border-red-300'
             }`}
           >
-            <div className="flex items-start gap-2">
+            <div className={`flex items-center gap-2 px-4 py-2 font-bold ${
+              result.status === 'success' 
+                ? 'bg-green-100 text-green-800' 
+                : 'bg-red-100 text-red-800'
+            }`}>
               {result.status === 'success' ? (
-                <CheckCircle className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <CheckCircle className="w-5 h-5 flex-shrink-0" />
               ) : (
-                <XCircle className="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" />
+                <XCircle className="w-5 h-5 flex-shrink-0" />
               )}
-              <div className="flex-1">
-                <div className={`font-bold mb-1 ${
-                  result.status === 'success' ? 'text-green-700' : 'text-red-700'
-                }`}>
-                  テスト {result.testCase} {result.status === 'success' ? '✅' : '❌'}
+              <span>テスト {result.testCase} {result.status === 'success' ? '✅' : '❌'}</span>
+            </div>
+            
+            <div className="p-4 space-y-3">
+              {result.status === 'forbidden' ? (
+                <div className="text-sm text-red-700 font-medium">
+                  ⚠️ APIキーを抜き取ろうとするコードは許可されていません！
                 </div>
+              ) : result.message ? (
                 <div className="text-sm text-slate-600 whitespace-pre-wrap">
-                  {result.status === 'forbidden'
-                    ? 'APIキーを抜き取ろうとするコードは許可されていません！'
-                    : result.message}
+                  {result.message}
                 </div>
-              </div>
+              ) : (
+                <>
+                  {/* 入力データ */}
+                  <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+                    <div className="flex items-center gap-2 mb-2">
+                      <div className="bg-slate-600 text-white px-3 py-1 rounded-md text-xs font-bold">
+                        📥 入力データ
+                      </div>
+                    </div>
+                    <div className="text-sm font-mono bg-white px-3 py-2 rounded border border-slate-200">
+                      {result.input && result.input.length > 0 
+                        ? result.input.map((item, i) => (
+                            <div key={i} className="text-slate-700">
+                              {typeof item === 'string' ? `"${item}"` : String(item)}
+                            </div>
+                          ))
+                        : <span className="text-slate-400">なし</span>
+                      }
+                    </div>
+                  </div>
+
+                  {/* 期待される出力 */}
+                  <div className="bg-indigo-50 rounded-lg p-3 border border-indigo-200">
+                    <div className="flex items-center gap-2 mb-2">
+                      <div className="bg-indigo-600 text-white px-3 py-1 rounded-md text-xs font-bold">
+                        🎯 正しい答え（期待される出力）
+                      </div>
+                    </div>
+                    <div className="text-sm font-mono bg-white px-3 py-2 rounded border border-indigo-200 text-slate-700">
+                      {result.expected_output || <span className="text-slate-400">なし</span>}
+                    </div>
+                  </div>
+
+                  {/* 実際の出力 */}
+                  <div className={`rounded-lg p-3 border ${
+                    result.status === 'success' 
+                      ? 'bg-emerald-50 border-emerald-200' 
+                      : 'bg-rose-50 border-rose-200'
+                  }`}>
+                    <div className="flex items-center gap-2 mb-2">
+                      <div className={`text-white px-3 py-1 rounded-md text-xs font-bold ${
+                        result.status === 'success' 
+                          ? 'bg-emerald-600' 
+                          : 'bg-rose-600'
+                      }`}>
+                        💻 あなたのプログラムの出力
+                      </div>
+                    </div>
+                    <div className={`text-sm font-mono bg-white px-3 py-2 rounded border ${
+                      result.status === 'success' 
+                        ? 'border-emerald-200 text-slate-700' 
+                        : 'border-rose-200 text-slate-700'
+                    }`}>
+                      {result.actual_output || <span className="text-slate-400">出力なし</span>}
+                    </div>
+                  </div>
+
+                  {/* 比較結果の説明 */}
+                  {result.status !== 'success' && (
+                    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+                      <div className="flex gap-2">
+                        <span className="text-yellow-600 text-xl">💡</span>
+                        <div className="flex-1">
+                          <div className="font-bold text-yellow-800 mb-1">ヒント</div>
+                          <div className="text-sm text-yellow-700">
+                            「正しい答え」と「あなたのプログラムの出力」を見比べてみましょう。<br/>
+                            どこが違うかな？スペースや改行も確認してみてね！
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/types/challengeEditor.ts
+++ b/frontend/src/types/challengeEditor.ts
@@ -9,7 +9,10 @@ export type HintLevel = {
 export type TestResult = {
   testCase: number;
   status: 'success' | 'failure' | 'forbidden' | 'error';
-  message: string;
+  message?: string;
+  input?: any[];
+  expected_output?: string;
+  actual_output?: string;
 };
 
 export interface SuccessModalProps {


### PR DESCRIPTION
## 変更内容

テスト結果の表示がわかりにくかった問題を解決し、プログラミング超初心者でも理解しやすいUIに改善しました。

### 主な改善点

1. **明確な情報の区別**
   - 📥 入力データ（グレー）
   - 🎯 正しい答え（インディゴ）
   - 💻 あなたのプログラムの出力（成功時：緑、失敗時：ローズ）
   - 各セクションに分かりやすいラベルを追加

2. **視覚的な改善**
   - 各情報を色分けして表示
   - カードデザインで見やすく整理
   - 目に優しい落ち着いた配色（チカチカしない）

3. **学習サポート**
   - テスト失敗時に比較のヒントを表示
   - 「どこが違うかな？」というガイドメッセージ

4. **バックエンド改善**
   - テスト結果を構造化して返却
   - フロントエンドで柔軟に表示可能に

### 変更ファイル
- `backend/code_runner.py` - テスト結果の構造化
- `frontend/src/types/challengeEditor.ts` - 型定義の更新
- `frontend/src/components/TestResults.tsx` - UIの改善
- `frontend/src/ChallengeEditor.tsx` - UIの改善

## スクリーンショット

<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/6adead8b-44b3-4728-aedf-89c84aeee7d2" />


## テスト
- ✅ リンターエラーなし
- ✅ 既存の動作に影響なし
- ✅ エラーメッセージの後方互換性あり（`message`フィールド使用時も動作）