### PR TITLE
[Fix]: Gemini3のモデル名を正しいものに修正

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,7 @@ PORT: int = 8000
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
 
 # Gemini API Configuration
-GEMINI_MODEL_CANDIDATES = ['gemini-3.0-flash', 'gemini-2.5-flash']
+GEMINI_MODEL_CANDIDATES = ['gemini-3-flash-preview', 'gemini-2.5-flash']
 GEMINI_TEMPERATURE = 1.0
 
 SYSTEM_INSTRUCTION: str = """\


### PR DESCRIPTION
## 変更内容
Gemini3.0のモデル名が間違っていたので、以下のように修正した。
- `gemini-3.0-flash` → `gemini-3-flash-preview`